### PR TITLE
Feat/dynamic layers

### DIFF
--- a/src/components/v-mapbox-layer.js
+++ b/src/components/v-mapbox-layer.js
@@ -10,6 +10,11 @@ export default {
         return {};
       },
       type: [Object, String]
+    },
+    // allows to place a layer before another
+    before: {
+      type: String,
+      required: false
     }
   },
   data() {
@@ -64,7 +69,12 @@ export default {
     },
     addLayer() {
       const map = this.getMap();
-      map.addLayer(this.options);
+
+      if (this.before) {
+        map.addLayer(this.options, this.before)
+      } else {
+        map.addLayer(this.options)
+      }
     }
   }
 };

--- a/src/components/v-mapbox-layer.js
+++ b/src/components/v-mapbox-layer.js
@@ -23,6 +23,7 @@ export default {
       isInitialized: false
     };
   },
+  // watch props and rerender if they change
   watch: {
     options: {
       deep: true,
@@ -30,6 +31,10 @@ export default {
         this.removeLayer();
         this.addLayer();
       }
+    },
+    before() {
+      this.removeLayer();
+      this.addLayer();
     }
   },
   mounted() {

--- a/src/components/v-mapbox-layer.js
+++ b/src/components/v-mapbox-layer.js
@@ -28,20 +28,17 @@ export default {
     options: {
       deep: true,
       handler() {
-        this.removeLayer();
-        this.addLayer();
+        this.rerender();
       }
     },
     before() {
-      this.removeLayer();
-      this.addLayer();
+      this.rerender();
     }
   },
   mounted() {
     // only execute when map is available and layer is not already initialized
     if (this.getMap()) {
-      this.removeLayer();
-      this.addLayer();
+      this.rerender();
       this.isInitialized = true;
     }
   },
@@ -52,8 +49,7 @@ export default {
     deferredMountedTo() {
       // only execute when layer is not already initialized
       if (!this.isInitialized) {
-        this.removeLayer();
-        this.addLayer();
+        this.rerender();
         this.isInitialized = true;
       }
     },
@@ -80,6 +76,10 @@ export default {
       } else {
         map.addLayer(this.options)
       }
+    },
+    rerender() {
+      this.removeLayer();
+      this.addLayer();
     }
   }
 };


### PR DESCRIPTION
Currently it is not possible to add layers dynamically, because deferredMountedTo only gets called on initialisation of the map. In this PR the (re)rendering is handled internaly in the `v-mapbox-layer` component, by either calling `mounted` or `deferredMountedTo`. When the layer is loaded later than the map is initialised, it uses`mounted`, otherwise `deferredMountedTo`. 