### PR TITLE
Remove map from data initialization so it is available but not reactive

### DIFF
--- a/src/components/VMapbox.vue
+++ b/src/components/VMapbox.vue
@@ -142,11 +142,6 @@ export const props = {
 
 export default {
   name: 'v-mapbox',
-  data () {
-    return {
-	    map: null
-    }
-  },
   props,
   provide () {
     // allows to use inject:  ['getMap']  in child components


### PR DESCRIPTION
For performance reasons it is desirable to not have a gigantic reactive map object. when that's unnecessary.
By not declaring it in `data` initialization, but still tacking it on the `this` in the component, we can use it in JS and pass it along to child components, but without it being augmented by Vue's reactivity system.