### PR TITLE
feat: add support for customAttribution

### DIFF
--- a/src/components/VMapbox.vue
+++ b/src/components/VMapbox.vue
@@ -113,6 +113,9 @@ export const props = {
   //   type: Boolean,
   //   default: true
   // },
+  customAttribution: {
+    type: [String, Array]
+  },
   // doubleClickZoom: {
   //   type: Boolean,
   //   default: true

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -106,6 +106,16 @@ const injectTemplate = `
 </v-mapbox>
 `
 
+const customAttributionTemplate = `
+<v-mapbox
+ map-style="mapbox://styles/mapbox/satellite-streets-v10"
+ access-token="pk.eyJ1IjoiZ2xvYmFsLWRhdGEtdmlld2VyIiwiYSI6ImNqdG9lYWQ3NTFsNWk0M3Fqb2Q5dXBpeWUifQ.3DvxuGByM33VNa59rDogWw"
+ style="height: 300px;"
+ :custom-attribution="['<a href=&quot;https://github.com/openearth/vue2mapbox-gl&quot;>Vue2Mapbox</a>', 'Custom attribution']"
+>
+</v-mapbox>
+`
+
 const layerA = {
   'id': 'a',
   'type': 'fill',
@@ -264,7 +274,11 @@ storiesOf('Map', module)
       }
     }
   })
-
+  .add('map with custom attribution', () => {
+    return {
+      template: customAttributionTemplate
+    }
+  })
   .add('map with navigation control', () => {
     return {
       template: navigationTemplate


### PR DESCRIPTION
Add support for `customAttribution`: String or strings to show in an [AttributionControl](https://docs.mapbox.com/mapbox-gl-js/api/markers/#attributioncontrol) . Only applicable if `options.attributionControl` is `true` .

The values are appended to the default attribution and separated by `|`

<img width="620" alt="image" src="https://user-images.githubusercontent.com/15196342/204554888-c10404e1-81a7-4ade-90cb-233412c89fdd.png">
