### PR TITLE
Remove object after destroy

### DIFF
--- a/src/components/VMapbox.vue
+++ b/src/components/VMapbox.vue
@@ -229,6 +229,7 @@ export default {
   destroyed () {
     if (this.map) {
       this.map.remove()
+      this.map = false
     }
   },
 }


### PR DESCRIPTION
Remove map object after destroy so there will be no further resize events fired.